### PR TITLE
docs(WEB-5613):  add atomic search page example on aem we.retail project sample

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -119,6 +119,17 @@
                         <artifactId>content-package-maven-plugin</artifactId>
                         <executions>
                             <execution>
+                                <id>uninstall-content-package</id>
+                                <phase>clean</phase>
+                                <goals>
+                                    <goal>uninstall</goal>
+                                </goals>
+                                <configuration>
+                                    <name>we.retail.all</name>
+                                    <failOnError>false</failOnError>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>install-package</id>
                                 <goals>
                                     <goal>install</goal>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -119,6 +119,11 @@
             <artifactId>geronimo-json_1.1_spec</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
 
         <!-- Other Dependencies -->
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -152,6 +152,7 @@
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
+                    <skip>true</skip>
                     <excludes combine.children="append">
                         <!--  Used by maven-remote-resources-plugin -->
                         <exclude>src/main/appended-resources/META-INF/*</exclude>
@@ -222,7 +223,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-scr-plugin</artifactId>
-                    <version>1.20.0</version>
+                    <version>1.26.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.slf4j</groupId>

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/content/searchresults/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/content/searchresults/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Search Results"
+    jcr:description="We.Retail Search Results"
+    cq:icon="search"
+    componentGroup="We.Retail"/>

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/content/searchresults/searchresults.html
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/content/searchresults/searchresults.html
@@ -1,0 +1,92 @@
+<sly>
+    <atomic-search-interface class="search-results-page">
+        <atomic-search-layout>
+            <atomic-layout-section section="search">
+                <atomic-search-box></atomic-search-box>
+            </atomic-layout-section>
+            <atomic-layout-section section="facets">
+                <atomic-facet-manager>
+                    <atomic-facet
+                            field="source"
+                            label="Source">
+                    </atomic-facet>
+                    <atomic-facet
+                            field="language"
+                            label="Language">
+                    </atomic-facet>
+                    <atomic-timeframe-facet
+                            is-collapsed="true"
+                            label="Timeframe"
+                            with-date-picker="true">
+                        <atomic-timeframe unit="hour"></atomic-timeframe>
+                        <atomic-timeframe unit="day"></atomic-timeframe>
+                        <atomic-timeframe unit="week"></atomic-timeframe>
+                        <atomic-timeframe unit="month"></atomic-timeframe>
+                        <atomic-timeframe unit="quarter"></atomic-timeframe>
+                        <atomic-timeframe unit="year"></atomic-timeframe>
+                    </atomic-timeframe-facet>
+                </atomic-facet-manager>
+            </atomic-layout-section>
+            <atomic-layout-section section="main">
+                <atomic-layout-section section="status">
+                    <atomic-breadbox></atomic-breadbox>
+                    <atomic-query-summary></atomic-query-summary>
+                    <atomic-refine-toggle></atomic-refine-toggle>
+                    <atomic-sort-dropdown>
+                        <atomic-sort-expression
+                            expression="relevancy descending"
+                            label="Relevance">
+                        </atomic-sort-expression>
+                        <atomic-sort-expression
+                            expression="date descending"
+                            label="Date">
+                        </atomic-sort-expression>
+                    </atomic-sort-dropdown>
+                    <atomic-did-you-mean></atomic-did-you-mean>
+                </atomic-layout-section>
+                <atomic-layout-section section="results">
+                    <atomic-result-list
+                        density="compact"
+                        display="grid"
+                        image-size="icon">
+                        <atomic-result-template>
+                            <template>
+                                <atomic-result-section-visual>
+                                    <atomic-result-icon></atomic-result-icon>
+                                </atomic-result-section-visual>
+                                <atomic-result-section-badges>
+                                    <atomic-result-badge
+                                        field="language"
+                                        icon="https://raw.githubusercontent.com/Rush/Font-Awesome-SVG-PNG/master/black/svg/language.svg">
+                                    </atomic-result-badge>
+                                </atomic-result-section-badges>
+                                <atomic-result-section-title-metadata>
+                                    <atomic-result-printable-uri></atomic-result-printable-uri>
+                                </atomic-result-section-title-metadata>
+                                <atomic-result-section-bottom-metadata>
+                                    <atomic-result-fields-list>
+                                        <atomic-field-condition if-defined="date">
+                                            <span class="field-label">Date Published:</span>
+                                            <atomic-result-date></atomic-result-date>
+                                        </atomic-field-condition>
+                                    </atomic-result-fields-list>
+                                </atomic-result-section-bottom-metadata>
+                                <atomic-result-section-title>
+                                    <atomic-result-link target="_blank"></atomic-result-link>
+                                </atomic-result-section-title>
+                                <atomic-result-section-excerpt>
+                                    <atomic-result-text field="excerpt"></atomic-result-text>
+                                </atomic-result-section-excerpt>
+                            </template>
+                        </atomic-result-template>
+                    </atomic-result-list>
+                    <atomic-query-error></atomic-query-error>
+                    <atomic-no-results></atomic-no-results>
+                </atomic-layout-section>
+                <atomic-layout-section section="pagination">
+                    <atomic-load-more-results></atomic-load-more-results>
+                </atomic-layout-section>
+            </atomic-layout-section>
+        </atomic-search-layout>
+    </atomic-search-interface>
+</sly>

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/css.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/css.txt
@@ -20,3 +20,4 @@ navbar.less
 header.less
 modal-search.less
 modal-signin.less
+coveo.less

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/js.txt
@@ -19,3 +19,4 @@
 modal-search.js
 subitems.js
 utilities.js
+coveo.js

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/js/coveo.js
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/js/coveo.js
@@ -1,0 +1,54 @@
+(async () => {
+    const initComponent = async (el) => {
+        await el.initialize({
+            accessToken: "xx63e73577-c09a-42cc-855c-0bc9b8f0fbc1",
+            organizationId: "adobedemor5tin3wu",
+        });
+    };
+
+    const initSearchResultPage = async () => {
+        const el = document.querySelector(".search-results-page");
+
+        // If the page does not have a search component.
+        if (!el) {
+            console.log('Coveo not initialized as no result page was found.');
+            return;
+        }
+
+        // Initialization
+        await initComponent(el);
+
+        // Trigger a first search
+        el.executeFirstSearch();
+    }
+
+    const initGlobalSearch = async () => {
+        const el = document.querySelector(".search-global");
+
+        // If the page does not have a search component.
+        if (!el) {
+            console.log('Coveo not initialized as no global search was found.');
+            return;
+        }
+
+        // Initialization
+        await initComponent(el);
+
+        // Trigger a first search
+        el.executeFirstSearch();
+    }
+
+    const coveoInit = async () => {
+        console.log('Coveo initializing.');
+
+        await import('https://static.cloud.coveo.com/atomic/v1/atomic.esm.js')
+            .catch(() => console.log('Error loading coveo scripts.'));
+
+        await customElements.whenDefined("atomic-search-interface");
+        await initSearchResultPage();
+        await initGlobalSearch();
+
+        console.log('Coveo initialized.');
+    };
+    await coveoInit();
+})();

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/less/coveo.less
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/less/coveo.less
@@ -1,0 +1,48 @@
+:root {
+    /* Primary colors */
+    --atomic-primary: #ed1c24;
+    --atomic-primary-light: #ff5f4e;
+    --atomic-primary-dark: #b20000;
+    --atomic-on-primary: #ffffff;
+    --atomic-ring-primary: rgba(237, 28, 66, 0.8);
+
+    /* Neutral colors */
+    --atomic-neutral-dark: #626971;
+    --atomic-neutral: #e5e8e8;
+    --atomic-neutral-light: #f6f7f9;
+
+    /* Semantic colors */
+    --atomic-background: #ffffff;
+    --atomic-on-background: #282829;
+    --atomic-success: #12a244;
+    --atomic-error: #ce3f00;
+    --atomic-visited: #752e9c;
+
+    /* Border radius */
+    --atomic-border-radius: 0.25rem;
+    --atomic-border-radius-md: 0.5rem;
+    --atomic-border-radius-lg: 0.75rem;
+    --atomic-border-radius-xl: 1rem;
+
+    /* Font */
+    --atomic-font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica,
+    Ubuntu, roboto, noto, arial, sans-serif; /* Following https://systemfontstack.com/ */
+    --atomic-font-normal: 400;
+    --atomic-font-bold: 700;
+
+    /* Text size */
+    --atomic-text-base: 0.875rem; /* 14px */
+    --atomic-text-sm: 0.75rem; /* 12px */
+    --atomic-text-lg: 1rem; /* 16px */
+    --atomic-text-xl: 1.125rem; /* 18px */
+    --atomic-text-2xl: 1.5rem; /* 24px */
+    --atomic-line-height-ratio: 1.5;
+
+    /* Layout */
+    --atomic-layout-spacing-x: 1.5rem;
+    --atomic-layout-spacing-y: 1rem;
+}
+
+.global-search-container {
+    background: var(--atomic-background);
+}

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/less/modal-search.less
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/clientlib/less/modal-search.less
@@ -217,7 +217,7 @@
 }
 
 .modal-color-primary .modal-backdrop {
-  background-color: @brand-primary;
+  background-color: black;
 
   &.in {
     opacity: .97;

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/include.html
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/include.html
@@ -61,7 +61,7 @@
 
         <!-- /.navbar-header -->
         <div class="collapse navbar-collapse width" id="we-example-navbar-collapse-inverse">
-            <ul  class="nav navbar-nav navbar-center">
+            <ul class="nav navbar-nav navbar-center">
                 <li class="visible-xs visible-sm"><a href="${header.languageRoot @ extension = 'html'}">we.<strong class="text-primary">Retail</strong></a></li>
                 <div class="we-navigation" data-sly-resource="${header.navigationResource @ decoration=false}"></div>
                 <li class="visible-xs visible-sm divider" role="separator"></li>

--- a/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/modals.html
+++ b/ui.apps/src/main/content/jcr_root/apps/weretail/components/structure/header/modals.html
@@ -24,9 +24,56 @@
             </div>
             <div class="modal-body">
                 <div class="row">
-                    <div class="col-md-12">
-                        <sly data-sly-test="${isCommunitiesPage}" data-sly-resource="${'./search' @ resourceType='weretail/components/structure/search', selectors='community'}"></sly>
-                        <sly data-sly-test="${!isCommunitiesPage}" data-sly-resource="${'./search' @ resourceType='weretail/components/structure/search', decoration='true'}"></sly>
+                    <div class="col-md-12 global-search-container">
+                        <atomic-search-interface class="search-global">
+                            <atomic-search-layout>
+                                <atomic-layout-section section="search">
+                                    <atomic-search-box>
+                                        <atomic-search-box-query-suggestions></atomic-search-box-query-suggestions>
+                                    </atomic-search-box>
+                                </atomic-layout-section>
+                                <atomic-layout-section section="main">
+                                    <atomic-layout-section section="status">
+                                        <atomic-breadbox></atomic-breadbox>
+                                        <atomic-query-summary></atomic-query-summary>
+                                        <atomic-refine-toggle></atomic-refine-toggle>
+                                        <atomic-sort-dropdown>
+                                            <atomic-sort-expression
+                                                    expression="relevancy descending"
+                                                    label="Relevance">
+                                            </atomic-sort-expression>
+                                            <atomic-sort-expression
+                                                    expression="date descending"
+                                                    label="Date">
+                                            </atomic-sort-expression>
+                                        </atomic-sort-dropdown>
+                                        <atomic-did-you-mean></atomic-did-you-mean>
+                                    </atomic-layout-section>
+                                    <atomic-layout-section section="results">
+                                        <atomic-result-list
+                                                density="compact"
+                                                display="list"
+                                                image-size="icon">
+                                            <atomic-result-template>
+                                                <template>
+                                                    <atomic-result-section-title-metadata>
+                                                        <atomic-result-printable-uri></atomic-result-printable-uri>
+                                                    </atomic-result-section-title-metadata>
+                                                    <atomic-result-section-title>
+                                                        <atomic-result-link target="_blank"></atomic-result-link>
+                                                    </atomic-result-section-title>
+                                                    <atomic-result-section-excerpt>
+                                                        <atomic-result-text field="excerpt"></atomic-result-text>
+                                                    </atomic-result-section-excerpt>
+                                                </template>
+                                            </atomic-result-template>
+                                        </atomic-result-list>
+                                        <atomic-query-error></atomic-query-error>
+                                        <atomic-no-results></atomic-no-results>
+                                    </atomic-layout-section>
+                                </atomic-layout-section>
+                            </atomic-search-layout>
+                        </atomic-search-interface>
                     </div>
                 </div>
             </div>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -123,6 +123,7 @@
                             <name>we.retail.ui.apps</name>
                             <version>[4.0.0,)</version>
                         </dependency>
+                        <!--https://github.com/adobe/aem-core-wcm-components/releases?expanded=true&page=2&q=2.4-->
                         <dependency>
                             <group>adobe/aem6/sample</group>
                             <name>we.retail.commons.content</name>

--- a/ui.content/src/main/content/jcr_root/content/we-retail/ca/en/search-results/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/we-retail/ca/en/search-results/.content.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="cq:Page">
+    <jcr:content
+            cq:contextHubPath="/libs/settings/cloudsettings/legacy/contexthub"
+            cq:contextHubSegmentsPath="/conf/we-retail/settings/wcm/segments"
+            jcr:created="{Date}2022-05-17T18:43:53.228+02:00"
+            cq:lastModified="{Date}2022-05-18T18:43:53.228+02:00"
+            cq:lastModifiedBy="admin"
+            cq:template="/conf/we-retail/settings/wcm/templates/hero-page"
+            jcr:primaryType="cq:PageContent"
+            jcr:title="Search results"
+            sling:resourceType="weretail/components/structure/page">
+        <root
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wcm/foundation/components/responsivegrid">
+            <hero_image
+                    jcr:created="{Date}2012-05-16T18:43:53.150+02:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2012-05-17T18:43:53.150+02:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="weretail/components/content/heroimage"
+                    fileReference="/content/dam/we-retail/en/activities/hiking-camping/trekker-ama-dablam.jpg"
+                    useFullWidth="true"/>
+            <responsivegrid
+                    cq:lastRolledout="{Date}2019-02-21T18:43:53.156+02:00"
+                    cq:lastRolledoutBy="admin"
+                    jcr:created="{Date}2016-01-13T15:58:09.854+01:00"
+                    jcr:createdBy="admin"
+                    jcr:lastModified="{Date}2019-02-21T18:43:53.154+02:00"
+                    jcr:lastModifiedBy="admin"
+                    jcr:mixinTypes="[cq:LiveRelationship]"
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="wcm/foundation/components/responsivegrid">
+                <searchresults
+                        cq:lastRolledout="{Date}2019-02-21T18:43:53.163+02:00"
+                        cq:lastRolledoutBy="admin"
+                        jcr:created="{Date}2019-02-15T15:57:39.854+02:00"
+                        jcr:createdBy="admin"
+                        jcr:lastModified="{Date}2019-02-15T15:57:57.096+02:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:mixinTypes="[cq:LiveRelationship]"
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="weretail/components/content/searchresults"/>
+            </responsivegrid>
+        </root>
+    </jcr:content>
+</jcr:root>


### PR DESCRIPTION
- adds search page results under [/us/en.html](http://localhost:4503/content/we-retail/us/en/search-results.html) and [/ca/en.html](http://localhost:4503/content/we-retail/ca/en/search-results.html)
- adds simple result list on search button.